### PR TITLE
Caching strategy updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: rust-ubuntu-format-clippy
+          shared-key: rust-ubuntu-${{ hashFiles('**/Cargo.lock') }}
 
       # Conditional steps based on the check type
       - name: Check formatting
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: rust-${{ matrix.os }}-test
+          shared-key: rust-${{ matrix.os }}-${{ hashFiles('**/Cargo.lock') }}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
@@ -86,7 +86,7 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: rust-windows-test
+          shared-key: rust-windows-${{ hashFiles('**/Cargo.lock') }}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
@@ -108,7 +108,7 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: rust-ubuntu-build
+          shared-key: rust-ubuntu-${{ hashFiles('**/Cargo.lock') }}
       - name: Build release
         run: cargo build --release --bin twig
       - name: Upload artifact
@@ -131,7 +131,7 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: rust-windows-build
+          shared-key: rust-windows-${{ hashFiles('**/Cargo.lock') }}
       - name: Build release
         run: cargo build --profile ci-windows --bin twig
       - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          key: ubuntu-release
+          shared-key: rust-ubuntu-${{ hashFiles('**/Cargo.lock') }}
       - name: Build release
         run: cargo build --release --bin twig
       - name: Strip binary
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          key: macos-release
+          shared-key: rust-macos-latest-${{ hashFiles('**/Cargo.lock') }}
       - name: Build release
         run: cargo build --release --bin twig
       - name: Strip binary
@@ -99,7 +99,7 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          key: windows-release
+          shared-key: rust-windows-latest-${{ hashFiles('**/Cargo.lock') }}
       - name: Build release
         run: cargo build --profile release-windows --bin twig
       - name: Extract version


### PR DESCRIPTION
This PR updates the caching strategy to use dynamic cache keys based on the Cargo.lock hash for more reliable cache invalidation across builds.

- Replace static cache keys with `shared-key` that includes `hashFiles('**/Cargo.lock')`
- Apply the new key format to release workflows (Ubuntu, macOS, Windows)
- Align CI workflows to use the same hash-based shared keys