### PR TITLE
feat: add Node.js and VS Code extension support to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,21 @@ ref/
 /target
 
 # Per-user secrets
+
+# Node.js
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.npm
+.node_repl_history
+# Note: package-lock.json and yarn.lock should be committed
+
+# TypeScript build output
+dist/
+build/
+*.tsbuildinfo
+
+# VS Code extension development
+*.vsix
 /.env


### PR DESCRIPTION
Adds comprehensive .gitignore entries for:
- Node.js dependencies (node_modules/, npm logs, .npm cache)
- TypeScript build artifacts (dist/, build/, *.tsbuildinfo)
- VS Code extension development (*.vsix files)

This supports the new twig-vscode extension development while ensuring package-lock.json and yarn.lock files are properly committed for reproducible builds.