### PR TITLE
Add setter to GitHubClient to support mock server tests

### DIFF
--- a/twig-cli/src/cli/switch.rs
+++ b/twig-cli/src/cli/switch.rs
@@ -994,7 +994,7 @@ mod tests {
       username: "user".to_string(),
       token: "token".to_string(),
     });
-    github_client.base_url = mock_server.uri();
+    github_client.set_base_url(mock_server.uri());
 
     create_branch_from_github_pr(&github_client, repo_guard.path(), 42, Some("parent"), None)?;
 

--- a/twig-gh/src/client.rs
+++ b/twig-gh/src/client.rs
@@ -33,6 +33,14 @@ impl GitHubClient {
     instance
   }
 
+  /// Overrides the base URL used for GitHub API requests.
+  ///
+  /// Primarily intended for tests that need to route requests through a mock
+  /// server.
+  pub fn set_base_url(&mut self, base_url: impl Into<String>) {
+    self.base_url = base_url.into();
+  }
+
   /// Test the GitHub connection by fetching the current user
   #[instrument(skip(self), level = "debug")]
   pub async fn test_connection(&self) -> Result<bool> {


### PR DESCRIPTION
## Summary
- add a public setter on `GitHubClient` to override the base URL when exercising mock servers
- update the CLI switch tests to use the setter instead of mutating the struct field directly

## Testing
- cargo check -p twig-cli

------
https://chatgpt.com/codex/tasks/task_e_68d74437b6648324884389759fcbae9b