### PR TITLE
Fetch GitHub PR heads when switching

### DIFF
--- a/SHORT_TERM_IMPROVEMENTS.md
+++ b/SHORT_TERM_IMPROVEMENTS.md
@@ -55,6 +55,8 @@ This plan focuses on core branch-centric flows that most Twig users rely on: `tw
 
 **Deliverables.** Updated GitHub client, enhanced switch flow, tests verifying SHA alignment, and documentation snippets in `README`/`USER_STORIES` if needed.
 
+**Status.** ✅ Completed — `twig switch` now fetches PR heads into dedicated tracking refs, configures upstream remotes, and verifies new branches inherit the GitHub head commit with tests covering the flow.
+
 ---
 
 ## P1 — Enrich `twig tree` with branch health signals

--- a/twig-gh/src/models.rs
+++ b/twig-gh/src/models.rs
@@ -43,8 +43,19 @@ pub struct GitHubPullRequest {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct PullRequestRef {
   pub label: String,
+  #[serde(alias = "ref")]
   pub ref_name: Option<String>,
   pub sha: String,
+  #[serde(default)]
+  pub repo: Option<PullRequestRepo>,
+}
+
+/// Metadata about the repository that backs a PR head or base reference
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct PullRequestRepo {
+  pub full_name: Option<String>,
+  pub clone_url: Option<String>,
+  pub ssh_url: Option<String>,
 }
 
 /// Represents a GitHub pull request review


### PR DESCRIPTION
## Summary
- extend the GitHub PR model to retain head repository URLs needed for fetching
- fetch PR head refs into a dedicated tracking namespace when creating branches from GitHub, wiring in upstream tracking and parent handling
- update the switch integration test to cover the fetched head commit and mark the short-term plan item complete

## Testing
- cargo check -p twig-cli -p twig-gh

------
https://chatgpt.com/codex/tasks/task_e_68d76b83f6e48324a1c62adcb5ca7b9d