### PR TITLE
Add CI and release badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # twig
 
+[![CI](https://github.com/eddieland/twig/actions/workflows/ci.yml/badge.svg)](https://github.com/eddieland/twig/actions/workflows/ci.yml)
+[![Latest Release](https://img.shields.io/github/v/release/eddieland/twig?display_name=tag&sort=semver)](https://github.com/eddieland/twig/releases/latest)
+
 A Git-based developer productivity tool that enhances workflows by integrating git repository management with Jira issue tracking and GitHub pull request workflows.
 
 ## Overview


### PR DESCRIPTION
## Summary
- add a GitHub Actions CI status badge to the README
- add a GitHub release badge highlighting the latest tag

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68dbf4fbfe6c83249d9301d2c4ee7529