### PR TITLE
Update MSRV documentation to Rust 1.90

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -2,7 +2,7 @@
 # See all lints at: https://rust-lang.github.io/rust-clippy/master/
 
 # Configure msrv (Minimum Supported Rust Version)
-msrv = "1.88.0"
+msrv = "1.90.0"
 
 disallowed-methods = []
 cognitive-complexity-threshold = 25

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ This document provides guidelines and instructions for contributing to the proje
 
 ### Setting Up the Right Toolchain
 
-Twig requires Rust 1.88.0 or later and uses the **nightly** toolchain for unstable rustfmt features. The project includes a `rust-toolchain.toml` file that specifies the exact requirements.
+Twig requires Rust 1.90.0 or later and uses the **nightly** toolchain for unstable rustfmt features. The project includes a `rust-toolchain.toml` file that specifies the exact requirements.
 
 ```bash
 # Simply navigate to the project directory and Rustup will automatically detect the toolchain file

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 [workspace.package]
 version = "0.2.0"
 edition = "2024"
-rust-version = "1.88.0"
+rust-version = "1.90.0"
 authors = ["Edward Jones <e@eddie.land>"]
 license = "MIT"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Twig streamlines common developer workflows across multiple repositories, provid
 ## Technology Stack
 
 - **Language**: Rust (Edition 2024)
-- **MSRV**: 1.88.0
+- **MSRV**: 1.90.0
 - **Target Platforms**: Ubuntu 24.04 (primary), macOS (secondary), Windows (tertiary)
 
 ## Installation
@@ -69,7 +69,7 @@ cargo install --path twig-cli
 ```
 
 **Requirements:**
-- Rust 1.88.0 or later
+- Rust 1.90.0 or later
 - Git
 
 ### Verify Installation


### PR DESCRIPTION
## Summary
- update the workspace MSRV setting to Rust 1.90.0 in Cargo metadata and Clippy configuration
- refresh README and contributing guide text to match the new MSRV value

## Testing
- make check *(fails: unable to download crates because of 403 CONNECT tunnel responses)*

------
https://chatgpt.com/codex/tasks/task_e_68dbfde1af848324a90f82903b31112a