### PR TITLE
Ignore twig state via internal gitignore

### DIFF
--- a/twig-cli/src/git.rs
+++ b/twig-cli/src/git.rs
@@ -52,8 +52,14 @@ pub fn add_repository<P: AsRef<Path>>(path: P) -> Result<()> {
   let config_dirs = ConfigDirs::new()?;
   let mut registry = Registry::load(&config_dirs)?;
 
-  registry.add(path)?;
+  let path_ref = path.as_ref();
+  let canonical_path = std::fs::canonicalize(path_ref)
+    .with_context(|| format!("Failed to resolve repository path {}", path_ref.display()))?;
+
+  registry.add(&canonical_path)?;
   registry.save(&config_dirs)?;
+
+  twig_core::state::ensure_twig_internal_gitignore(&canonical_path)?;
 
   Ok(())
 }


### PR DESCRIPTION
## Summary
- create a `.twig/.gitignore` that ignores all files in twig's state directory instead of mutating the repo's root `.gitignore`
- call the new helper from repo registration and state saves so tracked repositories remain clean
- update state tests to exercise the self-referential ignore behavior

## Testing
- cargo check --workspace

------
https://chatgpt.com/codex/tasks/task_e_68deed520d0883249837ec2687cd0837