### PR TITLE
Add --disable flag to selectively disable tool groups

### DIFF
--- a/twig-mcp/src/main.rs
+++ b/twig-mcp/src/main.rs
@@ -38,8 +38,6 @@ struct Cli {
   repo: Option<PathBuf>,
 
   /// Disable a group of tools. Can be specified multiple times.
-  ///
-  /// Available groups: github, jira, prompts
   #[arg(long = "disable", value_name = "GROUP")]
   disable: Vec<ToolGroup>,
 }

--- a/twig-mcp/src/main.rs
+++ b/twig-mcp/src/main.rs
@@ -16,7 +16,7 @@ use twig_core::config::ConfigDirs;
 use twig_core::git::detection::detect_repository;
 
 use crate::context::ServerContext;
-use crate::server::TwigMcpServer;
+use crate::server::{ToolGroup, TwigMcpServer};
 
 #[derive(Parser)]
 #[command(version, about = "MCP server for twig branch metadata, Jira issues, and GitHub PRs")]
@@ -36,6 +36,12 @@ struct Cli {
   /// Override repository path (defaults to auto-detection)
   #[arg(long = "repo", value_name = "PATH")]
   repo: Option<PathBuf>,
+
+  /// Disable a group of tools. Can be specified multiple times.
+  ///
+  /// Available groups: github, jira, prompts
+  #[arg(long = "disable", value_name = "GROUP")]
+  disable: Vec<ToolGroup>,
 }
 
 #[tokio::main]
@@ -63,7 +69,7 @@ async fn main() -> Result<()> {
     .to_path_buf();
 
   let context = ServerContext::new(config_dirs, repo_path, home_dir);
-  let server = TwigMcpServer::new(context);
+  let server = TwigMcpServer::new(context, &cli.disable);
 
   // Start MCP server on stdio
   let service = server.serve(rmcp::transport::io::stdio()).await?;

--- a/twig-mcp/src/server.rs
+++ b/twig-mcp/src/server.rs
@@ -887,11 +887,11 @@ fn build_tree_node(graph: &BranchGraph, state: &RepoState, name: &BranchName) ->
 
 #[cfg(test)]
 mod tests {
-  use super::*;
-
   use std::path::PathBuf;
 
   use twig_core::config::ConfigDirs;
+
+  use super::*;
 
   fn test_context() -> ServerContext {
     // Context with no repo — sufficient for testing router filtering.
@@ -904,11 +904,21 @@ mod tests {
   }
 
   fn tool_names(server: &TwigMcpServer) -> Vec<String> {
-    server.tool_router.list_all().into_iter().map(|t| t.name.to_string()).collect()
+    server
+      .tool_router
+      .list_all()
+      .into_iter()
+      .map(|t| t.name.to_string())
+      .collect()
   }
 
   fn prompt_names(server: &TwigMcpServer) -> Vec<String> {
-    server.prompt_router.list_all().into_iter().map(|p| p.name.to_string()).collect()
+    server
+      .prompt_router
+      .list_all()
+      .into_iter()
+      .map(|p| p.name.to_string())
+      .collect()
   }
 
   #[test]
@@ -965,7 +975,10 @@ mod tests {
 
   #[test]
   fn disable_multiple_groups() {
-    let server = TwigMcpServer::new(test_context(), &[ToolGroup::Github, ToolGroup::Jira, ToolGroup::Prompts]);
+    let server = TwigMcpServer::new(
+      test_context(),
+      &[ToolGroup::Github, ToolGroup::Jira, ToolGroup::Prompts],
+    );
     let tools = tool_names(&server);
     for name in GITHUB_TOOLS.iter().chain(JIRA_TOOLS.iter()) {
       assert!(!tools.contains(&name.to_string()), "tool {name} should be removed");

--- a/twig-mcp/src/server.rs
+++ b/twig-mcp/src/server.rs
@@ -36,6 +36,25 @@ const GITHUB_TOOLS: &[&str] = &["get_pull_request", "get_pr_status", "list_pull_
 const JIRA_TOOLS: &[&str] = &["get_jira_issue", "list_jira_issues"];
 const PROMPT_NAMES: &[&str] = &["stack-status", "branch-context"];
 
+impl ToolGroup {
+  /// MCP tool names that belong to this group.
+  pub fn tool_names(&self) -> &'static [&'static str] {
+    match self {
+      Self::Github => GITHUB_TOOLS,
+      Self::Jira => JIRA_TOOLS,
+      Self::Prompts => &[],
+    }
+  }
+
+  /// MCP prompt names that belong to this group.
+  pub fn prompt_names(&self) -> &'static [&'static str] {
+    match self {
+      Self::Github | Self::Jira => &[],
+      Self::Prompts => PROMPT_NAMES,
+    }
+  }
+}
+
 /// Arguments for the `branch-context` prompt.
 #[derive(Debug, schemars::JsonSchema, serde::Deserialize)]
 pub struct BranchContextArgs {
@@ -62,22 +81,11 @@ impl TwigMcpServer {
     let mut prompt_router = Self::prompt_router();
 
     for group in disabled {
-      match group {
-        ToolGroup::Github => {
-          for name in GITHUB_TOOLS {
-            tool_router.remove_route(name);
-          }
-        }
-        ToolGroup::Jira => {
-          for name in JIRA_TOOLS {
-            tool_router.remove_route(name);
-          }
-        }
-        ToolGroup::Prompts => {
-          for name in PROMPT_NAMES {
-            prompt_router.remove_route(name);
-          }
-        }
+      for name in group.tool_names() {
+        tool_router.remove_route(name);
+      }
+      for name in group.prompt_names() {
+        prompt_router.remove_route(name);
       }
     }
 

--- a/twig-mcp/src/server.rs
+++ b/twig-mcp/src/server.rs
@@ -20,6 +20,22 @@ use crate::tools::jira::{GetJiraIssueParams, ListJiraIssuesParams};
 use crate::tools::local::{BranchMetadataParams, BranchStackParams, BranchTreeParams};
 use crate::types::*;
 
+/// A group of tools that can be disabled via `--disable`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, clap::ValueEnum)]
+pub enum ToolGroup {
+  /// GitHub PR tools (get_pull_request, get_pr_status, list_pull_requests)
+  Github,
+  /// Jira issue tools (get_jira_issue, list_jira_issues)
+  Jira,
+  /// MCP prompts (stack-status, branch-context)
+  Prompts,
+}
+
+/// Tool names belonging to each group.
+const GITHUB_TOOLS: &[&str] = &["get_pull_request", "get_pr_status", "list_pull_requests"];
+const JIRA_TOOLS: &[&str] = &["get_jira_issue", "list_jira_issues"];
+const PROMPT_NAMES: &[&str] = &["stack-status", "branch-context"];
+
 /// Arguments for the `branch-context` prompt.
 #[derive(Debug, schemars::JsonSchema, serde::Deserialize)]
 pub struct BranchContextArgs {
@@ -32,16 +48,48 @@ pub struct TwigMcpServer {
   context: Arc<ServerContext>,
   tool_router: ToolRouter<Self>,
   prompt_router: PromptRouter<Self>,
+  tools_enabled: bool,
+  prompts_enabled: bool,
 }
 
 #[tool_router]
 impl TwigMcpServer {
-  pub fn new(context: ServerContext) -> Self {
+  /// Create a new server, removing tools/prompts for any disabled groups.
+  pub fn new(context: ServerContext, disabled: &[ToolGroup]) -> Self {
     let context = Arc::new(context);
+
+    let mut tool_router = Self::tool_router();
+    let mut prompt_router = Self::prompt_router();
+
+    for group in disabled {
+      match group {
+        ToolGroup::Github => {
+          for name in GITHUB_TOOLS {
+            tool_router.remove_route(name);
+          }
+        }
+        ToolGroup::Jira => {
+          for name in JIRA_TOOLS {
+            tool_router.remove_route(name);
+          }
+        }
+        ToolGroup::Prompts => {
+          for name in PROMPT_NAMES {
+            prompt_router.remove_route(name);
+          }
+        }
+      }
+    }
+
+    let tools_enabled = !tool_router.list_all().is_empty();
+    let prompts_enabled = !prompt_router.list_all().is_empty();
+
     Self {
       context,
-      tool_router: Self::tool_router(),
-      prompt_router: Self::prompt_router(),
+      tool_router,
+      prompt_router,
+      tools_enabled,
+      prompts_enabled,
     }
   }
 
@@ -685,7 +733,7 @@ impl ServerHandler for TwigMcpServer {
          Jira issues, and GitHub PRs for the current repository."
           .into(),
       ),
-      capabilities: ServerCapabilities::builder().enable_tools().enable_prompts().build(),
+      capabilities: build_capabilities(self.tools_enabled, self.prompts_enabled),
       ..Default::default()
     }
   }
@@ -694,6 +742,20 @@ impl ServerHandler for TwigMcpServer {
 // ===========================================================================
 // Helper functions
 // ===========================================================================
+
+/// Build `ServerCapabilities` with the appropriate flags.
+///
+/// The builder uses a typestate pattern, so we can't conditionally call
+/// `enable_tools()` / `enable_prompts()` on the same binding. Match all
+/// four combinations instead.
+fn build_capabilities(tools: bool, prompts: bool) -> ServerCapabilities {
+  match (tools, prompts) {
+    (true, true) => ServerCapabilities::builder().enable_tools().enable_prompts().build(),
+    (true, false) => ServerCapabilities::builder().enable_tools().build(),
+    (false, true) => ServerCapabilities::builder().enable_prompts().build(),
+    (false, false) => ServerCapabilities::builder().build(),
+  }
+}
 
 /// Get the current branch name from a repository path.
 fn get_current_branch_name(repo_path: &std::path::Path) -> anyhow::Result<Option<String>> {
@@ -820,6 +882,99 @@ fn build_tree_node(graph: &BranchGraph, state: &RepoState, name: &BranchName) ->
     children,
     jira_issue: meta.and_then(|m| m.jira_issue.clone()),
     pr_number: meta.and_then(|m| m.github_pr),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  use std::path::PathBuf;
+
+  use twig_core::config::ConfigDirs;
+
+  fn test_context() -> ServerContext {
+    // Context with no repo — sufficient for testing router filtering.
+    let config_dirs = ConfigDirs {
+      config_dir: PathBuf::from("/tmp/twig-mcp-test/config"),
+      data_dir: PathBuf::from("/tmp/twig-mcp-test/data"),
+      cache_dir: None,
+    };
+    ServerContext::new(config_dirs, None, PathBuf::from("/tmp"))
+  }
+
+  fn tool_names(server: &TwigMcpServer) -> Vec<String> {
+    server.tool_router.list_all().into_iter().map(|t| t.name.to_string()).collect()
+  }
+
+  fn prompt_names(server: &TwigMcpServer) -> Vec<String> {
+    server.prompt_router.list_all().into_iter().map(|p| p.name.to_string()).collect()
+  }
+
+  #[test]
+  fn no_groups_disabled_exposes_all_tools() {
+    let server = TwigMcpServer::new(test_context(), &[]);
+    let tools = tool_names(&server);
+    for name in GITHUB_TOOLS.iter().chain(JIRA_TOOLS.iter()) {
+      assert!(tools.contains(&name.to_string()), "expected tool {name}");
+    }
+    let prompts = prompt_names(&server);
+    for name in PROMPT_NAMES {
+      assert!(prompts.contains(&name.to_string()), "expected prompt {name}");
+    }
+    assert!(server.tools_enabled);
+    assert!(server.prompts_enabled);
+  }
+
+  #[test]
+  fn disable_github_removes_github_tools_only() {
+    let server = TwigMcpServer::new(test_context(), &[ToolGroup::Github]);
+    let tools = tool_names(&server);
+    for name in GITHUB_TOOLS {
+      assert!(!tools.contains(&name.to_string()), "tool {name} should be removed");
+    }
+    for name in JIRA_TOOLS {
+      assert!(tools.contains(&name.to_string()), "jira tool {name} should remain");
+    }
+    assert!(tools.contains(&"get_current_branch".to_string()));
+    assert!(server.tools_enabled);
+  }
+
+  #[test]
+  fn disable_jira_removes_jira_tools_only() {
+    let server = TwigMcpServer::new(test_context(), &[ToolGroup::Jira]);
+    let tools = tool_names(&server);
+    for name in JIRA_TOOLS {
+      assert!(!tools.contains(&name.to_string()), "tool {name} should be removed");
+    }
+    for name in GITHUB_TOOLS {
+      assert!(tools.contains(&name.to_string()), "github tool {name} should remain");
+    }
+    assert!(server.tools_enabled);
+  }
+
+  #[test]
+  fn disable_prompts_removes_all_prompts() {
+    let server = TwigMcpServer::new(test_context(), &[ToolGroup::Prompts]);
+    let prompts = prompt_names(&server);
+    assert!(prompts.is_empty(), "all prompts should be removed");
+    assert!(!server.prompts_enabled);
+    // Tools should be unaffected
+    assert!(server.tools_enabled);
+  }
+
+  #[test]
+  fn disable_multiple_groups() {
+    let server = TwigMcpServer::new(test_context(), &[ToolGroup::Github, ToolGroup::Jira, ToolGroup::Prompts]);
+    let tools = tool_names(&server);
+    for name in GITHUB_TOOLS.iter().chain(JIRA_TOOLS.iter()) {
+      assert!(!tools.contains(&name.to_string()), "tool {name} should be removed");
+    }
+    // Local tools remain
+    assert!(tools.contains(&"get_current_branch".to_string()));
+    assert!(tools.contains(&"list_branches".to_string()));
+    assert!(server.tools_enabled);
+    assert!(!server.prompts_enabled);
   }
 }
 


### PR DESCRIPTION
## Summary

- Add a `--disable` CLI flag that allows users to selectively disable groups of tools (GitHub, Jira, or Prompts)
- Implement `ToolGroup` enum with variants for each disableable group
- Modify `TwigMcpServer::new()` to accept a list of disabled groups and remove their routes from the tool/prompt routers
- Update server capabilities to only advertise enabled tools and prompts
- Add comprehensive unit tests covering all disable scenarios

## Related Issues / Tickets

- N/A

## Breaking Changes?

- [x] No
- [ ] Yes (describe):

## Implementation Details

The change introduces a new `ToolGroup` enum that categorizes tools into three groups:
- **GitHub**: `get_pull_request`, `get_pr_status`, `list_pull_requests`
- **Jira**: `get_jira_issue`, `list_jira_issues`
- **Prompts**: `stack-status`, `branch-context`

When a group is disabled via `--disable GROUP`, all tools in that group are removed from their respective routers before the server starts. The server tracks whether tools and prompts are enabled via boolean flags, which are used to build appropriate `ServerCapabilities`.

A helper function `build_capabilities()` handles the typestate pattern limitation of the builder by matching all four combinations of (tools_enabled, prompts_enabled).

## Checklist

- [x] I updated or added tests that cover my changes (or this change does not require tests).
  - Added 5 unit tests covering: no groups disabled, disable GitHub only, disable Jira only, disable Prompts only, and disable multiple groups
- [x] I updated documentation (README, docs/specs, comments) where necessary.
  - Added doc comments to `ToolGroup` enum and `build_capabilities()` function
  - Added help text to the `--disable` CLI argument
- [x] I verified this follows the CONTRIBUTING guidelines and coding standards.
- [ ] I added a changelog entry if required by the release process.

https://claude.ai/code/session_01FPw4nsWZpXoUYmmppLfBrE

## Summary by Sourcery

Add support for selectively disabling groups of MCP tools and prompts via a new CLI flag and propagate this configuration into the server’s routing and capabilities.

New Features:
- Introduce a ToolGroup enum to represent disableable groups of tools and prompts (GitHub, Jira, Prompts).
- Add a --disable CLI flag that accepts one or more tool groups to disable when starting the server.

Enhancements:
- Update TwigMcpServer initialization to filter tool and prompt routes based on disabled groups and track whether tools and prompts remain enabled.
- Adjust server capabilities construction to only advertise tools and/or prompts that are enabled via a helper builder function.

Tests:
- Add unit tests covering all combinations of disabled tool groups, ensuring routers and capability flags reflect the configuration.