### PR TITLE
Use GitHub API server-side head filter for PR branch lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3691,6 +3691,7 @@ dependencies = [
  "tracing",
  "twig-core",
  "twig-test-utils",
+ "url",
  "wiremock",
 ]
 

--- a/twig-cli/src/cli/github.rs
+++ b/twig-cli/src/cli/github.rs
@@ -675,7 +675,7 @@ fn handle_pr_list_command(cmd: &ListCommand) -> Result<()> {
   };
 
   println!("Fetching {} pull requests for {owner}/{repo_name}...", cmd.state);
-  match rt.block_on(github_client.list_pull_requests(&owner, &repo_name, Some(&cmd.state), Some(pagination))) {
+  match rt.block_on(github_client.list_pull_requests(&owner, &repo_name, Some(&cmd.state), None, Some(pagination))) {
     Ok(prs) => {
       if prs.is_empty() {
         println!("No {} pull requests found for {owner}/{repo_name}", cmd.state);

--- a/twig-gh/Cargo.toml
+++ b/twig-gh/Cargo.toml
@@ -10,6 +10,7 @@ authors.workspace = true
 # Core dependencies
 anyhow.workspace = true
 regex.workspace = true
+url.workspace = true
 
 # Async and networking
 reqwest.workspace = true

--- a/twig-gh/src/endpoints/pulls.rs
+++ b/twig-gh/src/endpoints/pulls.rs
@@ -22,13 +22,18 @@ impl Default for PaginationOptions {
 }
 
 impl GitHubClient {
-  /// List pull requests for a repository with pagination support
+  /// List pull requests for a repository with pagination support.
+  ///
+  /// If `head` is provided, GitHub will return only PRs whose head matches the
+  /// given filter. The expected format is `user:ref-name` or
+  /// `organization:ref-name`.
   #[instrument(skip(self), level = "debug")]
   pub async fn list_pull_requests(
     &self,
     owner: &str,
     repo: &str,
     state: Option<&str>,
+    head: Option<&str>,
     pagination_options: Option<PaginationOptions>,
   ) -> Result<Vec<GitHubPullRequest>> {
     // Set default state to "open" if not provided
@@ -40,10 +45,14 @@ impl GitHubClient {
       owner, repo, state_param
     );
 
-    let url = format!(
+    let mut url = format!(
       "{}/repos/{}/{}/pulls?state={}&per_page={}&page={}",
       self.base_url, owner, repo, state_param, pagination.per_page, pagination.page
     );
+    if let Some(head_filter) = head {
+      url.push_str("&head=");
+      url.push_str(head_filter);
+    }
 
     trace!("GitHub API URL: {}", url);
 
@@ -208,7 +217,13 @@ impl GitHubClient {
     Ok(status)
   }
 
-  /// Find pull requests by head branch name
+  /// Find pull requests by head branch name.
+  ///
+  /// Uses GitHub's server-side `head` filter (`owner:ref-name`) so the API
+  /// returns only matching PRs rather than the full repository PR list. PRs
+  /// opened from forks of other owners will not be discovered — the GitHub
+  /// API requires the head owner in the filter and we only know the base
+  /// repository's owner here.
   #[instrument(skip(self), level = "debug")]
   pub async fn find_pull_requests_by_head_branch(
     &self,
@@ -222,22 +237,10 @@ impl GitHubClient {
       owner, repo, branch_name
     );
 
-    // Get all pull requests for the repository
-    let pull_requests = self.list_pull_requests(owner, repo, state, None).await?;
-
-    // Filter pull requests by head branch name
-    let matching_prs: Vec<GitHubPullRequest> = pull_requests
-      .into_iter()
-      .filter(|pr| {
-        if let Some(ref_name) = &pr.head.ref_name {
-          ref_name == branch_name
-        } else {
-          // If ref_name is None, check if the branch name is in the label
-          // Label format is typically "username:branch-name"
-          pr.head.label.split(':').nth(1) == Some(branch_name)
-        }
-      })
-      .collect();
+    let head_filter = format!("{owner}:{branch_name}");
+    let matching_prs = self
+      .list_pull_requests(owner, repo, state, Some(&head_filter), None)
+      .await?;
 
     info!(
       "Found {} pull requests with head branch: {}",
@@ -307,7 +310,7 @@ mod tests {
       .await;
 
     let prs = client
-      .list_pull_requests("octocat", "Hello-World", Some("open"), None)
+      .list_pull_requests("octocat", "Hello-World", Some("open"), None, None)
       .await?;
 
     assert_eq!(prs.len(), 1);
@@ -371,7 +374,7 @@ mod tests {
 
     let pagination = PaginationOptions { per_page: 5, page: 2 };
     let prs = client
-      .list_pull_requests("octocat", "Hello-World", Some("closed"), Some(pagination))
+      .list_pull_requests("octocat", "Hello-World", Some("closed"), None, Some(pagination))
       .await?;
 
     assert_eq!(prs.len(), 1);
@@ -452,56 +455,30 @@ mod tests {
     let mut client = GitHubClient::new(auth);
     client.base_url = mock_server.uri();
 
-    // Mock response for pull requests
+    // The request must include head=owner:branch so GitHub filters server-side
+    // rather than returning the full repository PR list. Before this change the
+    // caller fetched the first page of PRs and filtered client-side, which
+    // silently missed branches whose PR was not among the 30 most-recent PRs.
     Mock::given(method("GET"))
       .and(path("/repos/octocat/Hello-World/pulls"))
-      .and(query_param("state", "open"))
-      .and(query_param("per_page", "30"))
-      .and(query_param("page", "1"))
+      .and(query_param("state", "all"))
+      .and(query_param("head", "octocat:older-branch"))
       .and(header(header::ACCEPT, ACCEPT))
       .and(header(header::USER_AGENT, USER_AGENT))
       .and(header(header::AUTHORIZATION, "Basic dGVzdF91c2VyOnRlc3RfdG9rZW4="))
       .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
         {
-          "id": 1,
-          "number": 1347,
+          "id": 2001,
+          "number": 2001,
           "state": "open",
-          "title": "Feature from target-branch",
-          "html_url": "https://github.com/octocat/Hello-World/pull/1347",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "type": "User"
-          },
-          "created_at": "2011-01-26T19:01:12Z",
-          "updated_at": "2011-01-26T19:01:12Z",
+          "title": "Feature from older-branch",
+          "html_url": "https://github.com/octocat/Hello-World/pull/2001",
+          "user": { "login": "octocat", "id": 1, "type": "User" },
+          "created_at": "2010-01-01T00:00:00Z",
+          "updated_at": "2010-01-01T00:00:00Z",
           "head": {
-            "label": "octocat:target-branch",
-            "ref": "target-branch",
-            "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
-          },
-          "base": {
-            "label": "octocat:master",
-            "ref": "master",
-            "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
-          }
-        },
-        {
-          "id": 2,
-          "number": 1348,
-          "state": "open",
-          "title": "Another feature",
-          "html_url": "https://github.com/octocat/Hello-World/pull/1348",
-          "user": {
-            "login": "octocat",
-            "id": 1,
-            "type": "User"
-          },
-          "created_at": "2011-01-26T19:01:12Z",
-          "updated_at": "2011-01-26T19:01:12Z",
-          "head": {
-            "label": "octocat:different-branch",
-            "ref": "different-branch",
+            "label": "octocat:older-branch",
+            "ref": "older-branch",
             "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
           },
           "base": {
@@ -514,16 +491,13 @@ mod tests {
       .mount(&mock_server)
       .await;
 
-    // Test finding pull requests by head branch
     let prs = client
-      .find_pull_requests_by_head_branch("octocat", "Hello-World", "target-branch", Some("open"))
+      .find_pull_requests_by_head_branch("octocat", "Hello-World", "older-branch", Some("all"))
       .await?;
 
-    // Verify we only got the PR with the matching head branch
     assert_eq!(prs.len(), 1);
-    assert_eq!(prs[0].number, 1347);
-    assert_eq!(prs[0].title, "Feature from target-branch");
-    assert_eq!(prs[0].head.ref_name, Some("target-branch".to_string()));
+    assert_eq!(prs[0].number, 2001);
+    assert_eq!(prs[0].head.ref_name, Some("older-branch".to_string()));
 
     Ok(())
   }

--- a/twig-gh/src/endpoints/pulls.rs
+++ b/twig-gh/src/endpoints/pulls.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use reqwest::header;
 use tracing::{debug, info, instrument, trace, warn};
+use url::Url;
 
 use crate::client::GitHubClient;
 use crate::consts::{ACCEPT, USER_AGENT};
@@ -45,20 +46,25 @@ impl GitHubClient {
       owner, repo, state_param
     );
 
-    let mut url = format!(
-      "{}/repos/{}/{}/pulls?state={}&per_page={}&page={}",
-      self.base_url, owner, repo, state_param, pagination.per_page, pagination.page
-    );
-    if let Some(head_filter) = head {
-      url.push_str("&head=");
-      url.push_str(head_filter);
+    // Build the URL via the `url` crate so query values (notably `head`, which
+    // embeds a user-supplied branch name) are percent-encoded correctly.
+    let mut url = Url::parse(&format!("{}/repos/{}/{}/pulls", self.base_url, owner, repo))
+      .context("Failed to construct pull requests URL")?;
+    {
+      let mut pairs = url.query_pairs_mut();
+      pairs.append_pair("state", state_param);
+      pairs.append_pair("per_page", &pagination.per_page.to_string());
+      pairs.append_pair("page", &pagination.page.to_string());
+      if let Some(head_filter) = head {
+        pairs.append_pair("head", head_filter);
+      }
     }
 
     trace!("GitHub API URL: {}", url);
 
     let response = self
       .client
-      .get(&url)
+      .get(url.clone())
       .header(header::ACCEPT, ACCEPT)
       .header(header::USER_AGENT, USER_AGENT)
       .basic_auth(&self.auth.username, Some(&self.auth.token))

--- a/twig-mcp/src/server.rs
+++ b/twig-mcp/src/server.rs
@@ -516,7 +516,10 @@ impl TwigMcpServer {
     };
 
     let state = params.0.state.as_deref();
-    match gh.list_pull_requests(&gh_repo.owner, &gh_repo.repo, state, None, None).await {
+    match gh
+      .list_pull_requests(&gh_repo.owner, &gh_repo.repo, state, None, None)
+      .await
+    {
       Ok(prs) => {
         let pull_requests: Vec<PullRequestResponse> = prs.iter().map(map_pull_request).collect();
         Ok(ToolResponse::ok(ListPullRequestsResponse { pull_requests }).to_call_tool_result())

--- a/twig-mcp/src/server.rs
+++ b/twig-mcp/src/server.rs
@@ -516,7 +516,7 @@ impl TwigMcpServer {
     };
 
     let state = params.0.state.as_deref();
-    match gh.list_pull_requests(&gh_repo.owner, &gh_repo.repo, state, None).await {
+    match gh.list_pull_requests(&gh_repo.owner, &gh_repo.repo, state, None, None).await {
       Ok(prs) => {
         let pull_requests: Vec<PullRequestResponse> = prs.iter().map(map_pull_request).collect();
         Ok(ToolResponse::ok(ListPullRequestsResponse { pull_requests }).to_call_tool_result())


### PR DESCRIPTION
## Summary

- Modified `list_pull_requests()` to accept an optional `head` parameter that filters PRs server-side using GitHub's `head` query parameter (format: `owner:ref-name`)
- Refactored `find_pull_requests_by_head_branch()` to use the new `head` filter instead of client-side filtering, eliminating the risk of missing PRs that fall outside the default pagination window
- Updated all call sites to pass the new `head` parameter (set to `None` where not needed)
- Updated tests to reflect the new API and verify server-side filtering behavior

## Related Issues / Tickets

- Fixes silent data loss when searching for PRs by branch name if the matching PR was not in the first page of results

## Breaking Changes?

- [x] No
- [ ] Yes (describe):

## Details

Previously, `find_pull_requests_by_head_branch()` would fetch the first page of PRs (30 results by default) and filter client-side by branch name. This silently missed branches whose PR was not among the most recent PRs in the repository.

This change leverages GitHub's server-side `head` filter to return only matching PRs, eliminating the pagination limitation. The filter format `owner:ref-name` is now constructed and passed to the API, ensuring complete and accurate results regardless of PR recency.

The implementation also includes improved documentation explaining the filter format and the limitation that PRs from forks with different owners cannot be discovered (a GitHub API constraint).

## Checklist

- [x] I updated or added tests that cover my changes (or this change does not require tests).
- [x] I updated documentation (README, docs/specs, comments) where necessary.
- [x] I verified this follows the CONTRIBUTING guidelines and coding standards.
- [ ] I added a changelog entry if required by the release process.

https://claude.ai/code/session_01RG2tkQBmnkif58Q7CpJnF4

## Summary by Sourcery

Use GitHub's server-side `head` filter when listing and searching pull requests to avoid missing PRs outside the default pagination window.

New Features:
- Add optional `head` filter parameter to the pull request listing API to delegate branch-based filtering to GitHub.

Bug Fixes:
- Ensure branch-based pull request lookups return all matching PRs by relying on GitHub's server-side `head` filter instead of client-side filtering over a single page of results.

Enhancements:
- Document the semantics and limitations of the GitHub `head` filter in the pull request lookup API.
- Adjust CLI and internal call sites to pass the new `head` parameter and maintain existing behavior where filtering is not needed.

Tests:
- Update and extend pull request listing and lookup tests to cover the new `head` filter behavior and verify correct GitHub API query parameters.