### PR TITLE
Prompt user when Jira-associated branch exists only on remote

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-latest]
+        os: [ubuntu-24.04, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/plugins/twig-flow/src/switch.rs
+++ b/plugins/twig-flow/src/switch.rs
@@ -109,6 +109,14 @@ pub fn run(cli: &Cli) -> Result<()> {
     return handle_stale_jira_association(&repo, repo_path, jira_parser.as_ref(), &stale);
   }
 
+  // Check if this is a Jira issue key whose associated branch exists on a remote but not locally.
+  // Without this check, the standard switch flow silently creates a tracking branch.
+  if let Some((branch_name, remote_ref)) =
+    detect_jira_remote_only_branch(&repo, &target, jira_parser.as_ref(), &repo_state)
+  {
+    return handle_remote_branch(&repo, repo_path, jira_parser.as_ref(), &branch_name, &remote_ref);
+  }
+
   // Check if this is a branch name (not Jira/PR) for potential branch creation prompt
   let switch_input = detect_switch_input(jira_parser.as_ref(), &target);
   let is_branch_name_input = matches!(switch_input, SwitchInput::BranchName(_));
@@ -238,6 +246,34 @@ fn detect_stale_jira_association(
     issue_key,
     stale_branch,
   })
+}
+
+/// Detect a Jira-associated branch that exists on a remote but not locally.
+///
+/// Returns `(branch_name, remote_ref)` when the local branch is missing but a
+/// remote tracking ref is present. This lets the caller prompt the user instead
+/// of silently creating a tracking branch.
+fn detect_jira_remote_only_branch(
+  repo: &Repository,
+  input: &str,
+  jira_parser: Option<&JiraTicketParser>,
+  repo_state: &RepoState,
+) -> Option<(String, String)> {
+  let issue_key = match detect_switch_input(jira_parser, input) {
+    SwitchInput::JiraIssueKey(key) | SwitchInput::JiraIssueUrl(key) => key,
+    _ => return None,
+  };
+
+  let branch_name = repo_state.get_branch_issue_by_jira(&issue_key)?.branch.clone();
+
+  if repo.find_branch(&branch_name, git2::BranchType::Local).is_ok() {
+    return None;
+  }
+
+  find_remote_branch(repo, &branch_name)
+    .ok()
+    .flatten()
+    .map(|remote_ref| (branch_name, remote_ref.as_str().to_string()))
 }
 
 /// Handle the case where a Jira issue's associated branch has been deleted.

--- a/plugins/twig-flow/src/switch.rs
+++ b/plugins/twig-flow/src/switch.rs
@@ -99,27 +99,22 @@ pub fn run(cli: &Cli) -> Result<()> {
   let repo_state = RepoState::load(repo_path).unwrap_or_else(|_| RepoState::default());
   let jira_parser = create_jira_parser().or_else(|| Some(JiraTicketParser::new_default()));
 
-  // Check if this is a Jira issue key without an existing association
-  if let Some(issue_key) = detect_jira_without_association(&target, jira_parser.as_ref(), &repo_state) {
-    return handle_jira_branch_creation(&repo, repo_path, &repo_state, jira_parser.as_ref(), &issue_key);
-  }
-
-  // Check if this is a Jira issue key whose associated branch was deleted.
-  if let Some(stale) = detect_stale_jira_association(&repo, &target, jira_parser.as_ref(), &repo_state) {
-    return handle_stale_jira_association(&repo, repo_path, jira_parser.as_ref(), &stale);
-  }
-
-  // Check if this is a Jira issue key whose associated branch exists on a remote but not locally.
-  // Without this check, the standard switch flow silently creates a tracking branch.
-  if let Some((branch_name, remote_ref)) =
-    detect_jira_remote_only_branch(&repo, &target, jira_parser.as_ref(), &repo_state)
-  {
-    return handle_remote_branch(&repo, repo_path, jira_parser.as_ref(), &branch_name, &remote_ref);
-  }
-
-  // Check if this is a branch name (not Jira/PR) for potential branch creation prompt
   let switch_input = detect_switch_input(jira_parser.as_ref(), &target);
   let is_branch_name_input = matches!(switch_input, SwitchInput::BranchName(_));
+
+  // Route all Jira inputs through specialized handlers before falling through
+  // to the generic switch flow.
+  if let SwitchInput::JiraIssueKey(ref issue_key) | SwitchInput::JiraIssueUrl(ref issue_key) = switch_input {
+    if repo_state.get_branch_issue_by_jira(issue_key).is_none() {
+      return handle_jira_branch_creation(&repo, repo_path, &repo_state, jira_parser.as_ref(), issue_key);
+    }
+    if let Some(stale) = detect_stale_jira_association(&repo, issue_key, &repo_state) {
+      return handle_stale_jira_association(&repo, repo_path, jira_parser.as_ref(), &stale);
+    }
+    if let Some((branch_name, remote_ref)) = detect_jira_remote_only_branch(&repo, issue_key, &repo_state) {
+      return handle_remote_branch(&repo, repo_path, jira_parser.as_ref(), &branch_name, &remote_ref);
+    }
+  }
 
   // For branch name inputs, check if the branch exists locally first.
   // If it doesn't exist locally but exists on remote, prompt the user.
@@ -176,26 +171,6 @@ pub fn run(cli: &Cli) -> Result<()> {
   Ok(())
 }
 
-/// Check if the input is a Jira issue key without an existing branch
-/// association.
-fn detect_jira_without_association(
-  input: &str,
-  jira_parser: Option<&JiraTicketParser>,
-  repo_state: &RepoState,
-) -> Option<String> {
-  match detect_switch_input(jira_parser, input) {
-    SwitchInput::JiraIssueKey(key) | SwitchInput::JiraIssueUrl(key) => {
-      // Check if there's already an associated branch
-      if repo_state.get_branch_issue_by_jira(&key).is_some() {
-        None // Has association, use normal flow
-      } else {
-        Some(key) // No association, needs user prompt
-      }
-    }
-    _ => None, // Not a Jira issue
-  }
-}
-
 /// Context describing a Jira association whose branch has been deleted.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct StaleJiraAssociation {
@@ -212,16 +187,10 @@ struct StaleJiraAssociation {
 /// try to check out the missing branch and fail with a fetch error.
 fn detect_stale_jira_association(
   repo: &Repository,
-  input: &str,
-  jira_parser: Option<&JiraTicketParser>,
+  issue_key: &str,
   repo_state: &RepoState,
 ) -> Option<StaleJiraAssociation> {
-  let issue_key = match detect_switch_input(jira_parser, input) {
-    SwitchInput::JiraIssueKey(key) | SwitchInput::JiraIssueUrl(key) => key,
-    _ => return None,
-  };
-
-  let branch_issue = repo_state.get_branch_issue_by_jira(&issue_key)?;
+  let branch_issue = repo_state.get_branch_issue_by_jira(issue_key)?;
   let stale_branch = branch_issue.branch.clone();
 
   // If the branch is still present locally, the association is fine.
@@ -243,7 +212,7 @@ fn detect_stale_jira_association(
   }
 
   Some(StaleJiraAssociation {
-    issue_key,
+    issue_key: issue_key.to_string(),
     stale_branch,
   })
 }
@@ -255,16 +224,10 @@ fn detect_stale_jira_association(
 /// of silently creating a tracking branch.
 fn detect_jira_remote_only_branch(
   repo: &Repository,
-  input: &str,
-  jira_parser: Option<&JiraTicketParser>,
+  issue_key: &str,
   repo_state: &RepoState,
 ) -> Option<(String, String)> {
-  let issue_key = match detect_switch_input(jira_parser, input) {
-    SwitchInput::JiraIssueKey(key) | SwitchInput::JiraIssueUrl(key) => key,
-    _ => return None,
-  };
-
-  let branch_name = repo_state.get_branch_issue_by_jira(&issue_key)?.branch.clone();
+  let branch_name = repo_state.get_branch_issue_by_jira(issue_key)?.branch.clone();
 
   if repo.find_branch(&branch_name, git2::BranchType::Local).is_ok() {
     return None;
@@ -965,42 +928,6 @@ mod tests {
   }
 
   #[test]
-  fn detects_jira_without_association() {
-    let parser = JiraTicketParser::new_default();
-    let state = RepoState::default();
-
-    // Should detect Jira issue without association
-    let result = detect_jira_without_association("PROJ-123", Some(&parser), &state);
-    assert_eq!(result, Some("PROJ-123".to_string()));
-
-    // Should not detect branch names
-    let result = detect_jira_without_association("feature/branch", Some(&parser), &state);
-    assert_eq!(result, None);
-
-    // Should not detect numbers (GitHub PR)
-    let result = detect_jira_without_association("123", Some(&parser), &state);
-    assert_eq!(result, None);
-  }
-
-  #[test]
-  fn detects_jira_with_association() -> Result<()> {
-    let parser = JiraTicketParser::new_default();
-    let mut state = RepoState::default();
-    state.add_branch_issue(BranchMetadata {
-      branch: "existing-branch".into(),
-      jira_issue: Some("PROJ-123".into()),
-      github_pr: None,
-      created_at: "now".into(),
-    });
-
-    // Should not detect because association exists
-    let result = detect_jira_without_association("PROJ-123", Some(&parser), &state);
-    assert_eq!(result, None);
-
-    Ok(())
-  }
-
-  #[test]
   fn detects_stale_jira_association_when_branch_is_missing() -> Result<()> {
     let guard = GitRepoTestGuard::new_and_change_dir();
     create_commit(&guard.repo, "file.txt", "content", "initial")?;
@@ -1017,9 +944,8 @@ mod tests {
     });
     state.save(repo_path)?;
 
-    let parser = JiraTicketParser::new_default();
     let state = RepoState::load(repo_path)?;
-    let stale = detect_stale_jira_association(&guard.repo, "ME-19008", Some(&parser), &state);
+    let stale = detect_stale_jira_association(&guard.repo, "ME-19008", &state);
 
     assert_eq!(
       stale,
@@ -1048,9 +974,8 @@ mod tests {
     });
     state.save(repo_path)?;
 
-    let parser = JiraTicketParser::new_default();
     let state = RepoState::load(repo_path)?;
-    let stale = detect_stale_jira_association(&guard.repo, "PROJ-123", Some(&parser), &state);
+    let stale = detect_stale_jira_association(&guard.repo, "PROJ-123", &state);
 
     assert_eq!(stale, None);
     Ok(())
@@ -1061,9 +986,8 @@ mod tests {
     let guard = GitRepoTestGuard::new_and_change_dir();
     create_commit(&guard.repo, "file.txt", "content", "initial")?;
 
-    let parser = JiraTicketParser::new_default();
     let state = RepoState::default();
-    let stale = detect_stale_jira_association(&guard.repo, "PROJ-123", Some(&parser), &state);
+    let stale = detect_stale_jira_association(&guard.repo, "PROJ-123", &state);
 
     assert_eq!(stale, None);
     Ok(())
@@ -1113,9 +1037,8 @@ mod tests {
     });
     state.save(repo_path)?;
 
-    let parser = JiraTicketParser::new_default();
     let state = RepoState::load(repo_path)?;
-    let stale = detect_stale_jira_association(&guard.repo, "PROJ-500", Some(&parser), &state);
+    let stale = detect_stale_jira_association(&guard.repo, "PROJ-500", &state);
 
     assert_eq!(stale, None, "upstream-cached branch should not be flagged stale");
     Ok(())


### PR DESCRIPTION
## Summary

- `twig flow <JIRA-KEY>` was silently creating a local tracking branch when the associated branch existed on origin but not locally (e.g. after `git branch -D`)
- The `detect_stale_jira_association` check intentionally skips this case (remote ref present = not stale), so the standard switch flow ran and called `try_checkout_remote_branch` without asking
- Added `detect_jira_remote_only_branch` to catch this case and route it through the existing `handle_remote_branch` prompt, giving the user the same options as plain branch-name inputs: checkout remote, create fresh local branch, custom name, or abort

## Test plan

- [ ] Delete a local branch that has a Jira association and still exists on origin
- [ ] Run `twig flow <JIRA-KEY>` — verify an interactive prompt appears instead of silent checkout
- [ ] Verify all three prompt options work: checkout remote, create local, abort
- [ ] Verify `twig flow <JIRA-KEY>` still works normally when the local branch exists
- [ ] Verify the stale association path (branch deleted from both local and remote) still prompts correctly

https://claude.ai/code/session_01HQmDuK6MamT7jwXU1wy6Kk

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQmDuK6MamT7jwXU1wy6Kk)_

## Summary by Sourcery

Prompt when switching to a Jira-associated branch that exists only on the remote, and simplify Jira association detection logic.

New Features:
- Add detection for Jira-associated branches that exist only on a remote and route them through the existing remote-branch prompt flow.

Enhancements:
- Refactor Jira switch handling to route Jira issue and URL inputs through a unified specialized handler before the generic switch flow.
- Simplify stale Jira association detection to work directly from an issue key and reuse existing repo state lookups.

CI:
- Update CI test matrix to use macOS 15 instead of the generic macOS-latest runner.